### PR TITLE
[FEAT] 가족 탈퇴 API

### DIFF
--- a/src/main/java/gamo/web/family/controller/FamilyController.java
+++ b/src/main/java/gamo/web/family/controller/FamilyController.java
@@ -6,6 +6,7 @@ import gamo.web.member.service.MemberService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +23,16 @@ public class FamilyController {
     @PostMapping("/invite")
     public ResponseEntity<Map<String, String>> inviteFamily(@AuthenticationPrincipal UserPrincipal user) {
         Long memberId = memberService.getMemberId(user);
-       if(familyService.hasFamily(memberId)) {
+        // 이미 가족에 가입되어 있는 사람이라면, 그 가족의 코드를 보여준다
+        if(familyService.hasFamily(memberId)) {
            String code =  familyService.getFamilyCode(memberId);
            return ResponseEntity.ok().body(Map.of("familyCode", code));
-       }
+        }
 
-       familyService.inviteFamily(memberId);
-       String code =  familyService.getFamilyCode(memberId);
-       return ResponseEntity.ok().body(Map.of("familyCode", code));
+        // 아니라고 하면, 코드 새로 생성해서 그걸 보내줌
+        familyService.inviteFamily(memberId);
+        String code =  familyService.getFamilyCode(memberId);
+        return ResponseEntity.ok().body(Map.of("familyCode", code));
     }
 
     @Getter
@@ -38,11 +41,17 @@ public class FamilyController {
         private String inviteCode;
     }
 
+    // 가족 코드 입력해서 그 가족에 들어가기(초대받기)
     @PostMapping("/join")
-    public ResponseEntity<Void> joinFamily(@AuthenticationPrincipal UserPrincipal user,
+    public ResponseEntity<Map<String, String>> joinFamily(@AuthenticationPrincipal UserPrincipal user,
                                            @RequestBody InviteCode inviteCode) {
         Long memberId = memberService.getMemberId(user);
+
+        if (familyService.hasFamily(memberId)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("message", "이미 가입된 가족이 있습니다."));
+        }
         familyService.joinFamily(memberId, inviteCode.getInviteCode());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(Map.of("message", "가족 참여 완료!"));
     }
 }

--- a/src/main/java/gamo/web/family/controller/FamilyController.java
+++ b/src/main/java/gamo/web/family/controller/FamilyController.java
@@ -54,4 +54,18 @@ public class FamilyController {
         familyService.joinFamily(memberId, inviteCode.getInviteCode());
         return ResponseEntity.ok(Map.of("message", "가족 참여 완료!"));
     }
+
+    @PostMapping("/leave")
+    public ResponseEntity<Map<String, String>> leaveFamily(@AuthenticationPrincipal UserPrincipal user) {
+        Long memberId = memberService.getMemberId(user);
+
+        if(!familyService.hasFamily(memberId)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "가입된 가족이 없습니다"));
+        }
+
+        familyService.leaveFamily(memberId);
+        return ResponseEntity.ok(Map.of("message", "가족 탈퇴 완료"));
+    }
+
 }

--- a/src/main/java/gamo/web/family/service/FamilyService.java
+++ b/src/main/java/gamo/web/family/service/FamilyService.java
@@ -88,4 +88,23 @@ public class FamilyService {
         member.setFamily(family);
         memberRepository.save(member);
     }
+
+    // 가족 탈퇴
+    @Transactional
+    public void leaveFamily(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Family family = member.getFamily();
+        if(family == null) {
+            throw new CustomException(ErrorCode.FAMILY_NOT_FOUND);
+        }
+
+        member.setFamily(null);
+
+        // 만약, 가족 구성원이 한 명도 안남아있다면 그 가족 엔티티를 삭제한다
+        if(!memberRepository.existsByFamily(family)) {
+            familyRepository.delete(family);
+        }
+    }
 }

--- a/src/main/java/gamo/web/member/controller/MemberController.java
+++ b/src/main/java/gamo/web/member/controller/MemberController.java
@@ -17,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/member")
 @RequiredArgsConstructor
@@ -63,16 +65,14 @@ public class MemberController {
 
     //회원 탈퇴
     @DeleteMapping
-    public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal UserPrincipal user,
-                                             HttpServletRequest request,
-                                             HttpServletResponse response) {
+    public ResponseEntity<Map<String, String>> deleteMember(@AuthenticationPrincipal UserPrincipal user,
+                                                            HttpServletRequest request,
+                                                            HttpServletResponse response) {
         Long memberId = memberService.getMemberId(user);
         memberService.deleteMember(memberId);
 
         logoutService.performLogout(request, response);
 
-        return ResponseEntity.status(303)
-                .header("Location", "/login")
-                .build();
+        return ResponseEntity.ok(Map.of("message", "회원 탈퇴 완료"));
     }
 }

--- a/src/main/java/gamo/web/member/repository/MemberRepository.java
+++ b/src/main/java/gamo/web/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     //나는 제외하고 ACTIVE 상태인 가족들 찾는 함수
     List<Member> findAllByFamilyAndIdNotAndStatus(Family family, Long excludeId, Member.MemberStatus status);
+
+    boolean existsByFamily(Family family);
 }

--- a/src/main/resources/templates/fragments/action-modal.html
+++ b/src/main/resources/templates/fragments/action-modal.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<th:block th:fragment="actionModal(modalId, actionMessage, okText, cancelText)">
+
+    <!-- 오버레이 + 모달 -->
+    <div th:id="${modalId}"
+         data-action-modal
+         class="fixed inset-0 z-[1200] hidden px-5
+                flex items-center justify-center
+                bg-black/40 backdrop-blur-sm">
+
+        <div class="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
+
+            <!-- 메시지 -->
+            <p class="mt-3 text-m text-gray-600 font-bold"
+               data-action-message
+               th:text="${actionMessage}">
+                액션 메시지
+            </p>
+
+            <!-- 버튼 영역 -->
+            <div class="mt-6 flex gap-3">
+                <!-- 확인 버튼 -->
+                <button type="button"
+                        data-action-ok
+                        th:text="${okText}"
+                        class="flex-1 rounded-xl bg-amber-400 px-4 py-2
+                               text-m font-semibold text-white transition-colors">
+                    확인
+                </button>
+
+                <!-- 닫기 버튼 -->
+                <button type="button"
+                        data-modal-close
+                        th:text="${cancelText}"
+                        class="flex-1 rounded-xl border border-gray-300 px-4 py-2
+                               text-m font-semibold text-gray-700 bg-white transition-colors">
+                    닫기
+                </button>
+            </div>
+
+        </div>
+    </div>
+
+    <script>
+        // openActionModal('modalId', '메시지', () => { 실행할 코드 })
+        window.openActionModal = function (id, message, onConfirm) {
+            const modal = document.getElementById(id);
+            if (!modal) return;
+
+            // 메시지 업데이트
+            if (message) {
+                const msgEl = modal.querySelector('[data-action-message]');
+                if (msgEl) msgEl.textContent = message;
+            }
+
+            // onConfirm 콜백 저장
+            modal._onConfirm = (typeof onConfirm === 'function') ? onConfirm : null;
+
+            // 포커스 해제 (input 자동완성 막기)
+            if (document.activeElement && document.activeElement.blur) {
+                document.activeElement.blur();
+            }
+
+            modal.classList.remove('hidden');
+            document.body.style.overflow = 'hidden';
+        }
+
+        // 모달 닫기
+        function closeActionModal(modal) {
+            modal.classList.add('hidden');
+            document.body.style.overflow = '';
+            modal._onConfirm = null; // 콜백 제거
+        }
+
+        // 이벤트 위임
+        document.addEventListener('click', function (e) {
+
+            // 확인 버튼
+            if (e.target.matches('[data-action-ok]')) {
+                const modal = e.target.closest('[data-action-modal]');
+                if (!modal) return;
+
+                const handler = modal._onConfirm;
+                closeActionModal(modal);
+
+                // 콜백 실행
+                if (typeof handler === 'function') {
+                    handler();
+                }
+            }
+
+            // 닫기 버튼
+            if (e.target.matches('[data-modal-close]')) {
+                const modal = e.target.closest('[data-action-modal]');
+                if (modal) closeActionModal(modal);
+            }
+
+            // 오버레이 클릭 시 닫기
+            if (e.target.matches('[data-action-modal]')) {
+                closeActionModal(e.target);
+            }
+        });
+    </script>
+
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/member/mypage.html
+++ b/src/main/resources/templates/pages/member/mypage.html
@@ -35,20 +35,11 @@
             </form>
 
             <!-- 가족탈퇴 -->
-            <a th:href="@{/member/family/leave}"
-               class="mx-auto block w-[200px] rounded-full bg-white px-6 py-3 text-center text-[14px] font-semibold text-gray-900 shadow-md">
+            <button id="leaveFamilyBtn" type="button"
+                    class="mx-auto block w-[200px] rounded-full bg-white px-6 py-3 text-center text-[14px] font-semibold text-gray-900 shadow-md">
                 가족탈퇴
-            </a>
+            </button>
 
-            <!-- 회원탈퇴 -->
-<!--            <form th:action="@{/api/member}" method="post"-->
-<!--                  onsubmit="return confirm('정말 탈퇴하시겠어요?');">-->
-<!--                <input type="hidden" name="_method" value="delete" />-->
-<!--                <button type="submit"-->
-<!--                        class="mx-auto block w-[200px] rounded-full bg-white px-6 py-3 text-center text-[14px] font-semibold text-gray-400 shadow-md">-->
-<!--                    회원탈퇴-->
-<!--                </button>-->
-<!--            </form>-->
             <!-- 회원탈퇴 -->
             <form id="deleteMemberForm" class="w-full">
                 <button type="submit"
@@ -75,69 +66,98 @@
     <script>
         (function () {
             const deleteForm = document.getElementById('deleteMemberForm');
-            if (!deleteForm) return;
+            const leaveFamilyBtn = document.getElementById('leaveFamilyBtn');
 
-            deleteForm.addEventListener('submit', (e) => {
-                e.preventDefault();
+            // CSRF 토큰
+            const csrfToken =
+                document.querySelector('meta[name="_csrf"]')?.content ||
+                document.querySelector('input[name="_csrf"]')?.value;
 
-                openActionModal('deleteConfirm', '정말 탈퇴하시겠어요?', async () => {
+            // 회원탈퇴랑 가족탈퇴 둘이 같은 함수로 묶기(액션이 비슷함)
+            async function sendActionRequest({ url, method, defaultSuccessMsg, defaultErrorMsg, redirectUrl }) {
+                try {
+                    const res = await fetch(url, {
+                        method,
+                        headers: {
+                            ...(csrfToken ? { 'X-CSRF-TOKEN': csrfToken } : {}),
+                        },
+                    });
 
-                    const token =
-                        document.querySelector('meta[name="_csrf"]')?.content ||
-                        document.querySelector('input[name="_csrf"]')?.value;
+                    let msg = defaultSuccessMsg;
 
-                    try {
-                        const res = await fetch('/api/member', {
-                            method: 'DELETE',
-                            headers: {
-                                ...(token ? { 'X-CSRF-TOKEN': token } : {}),
-                            },
-                        });
-
-                        let msg = '회원 탈퇴가 완료되었습니다.';
-
-                        if (res.ok) {
-                            try {
-                                const data = await res.json();
-                                if (data?.message) msg = data.message;
-                            } catch (_) {}
-                        } else {
-                            msg = '회원 탈퇴 처리에 실패했습니다.';
-                            try {
-                                const data = await res.json();
-                                if (data?.message) msg = data.message;
-                            } catch (_) {}
-                        }
-
-                        // 탈퇴 결과 알람 모달
-                        openAlertModal('commonAlert', msg);
-
-                        const alertModal = document.getElementById('commonAlert');
-                        if (!alertModal) return;
-
-                        const closeBtn = alertModal.querySelector('[data-modal-close]');
-                        if (!closeBtn) return;
-
-                        const handler = () => {
-                            closeBtn.removeEventListener('click', handler);
-
-                            if (res.ok) {
-                                // 성공했을 때만 로그인 페이지로 이동
-                                window.location.href = '/login';
-                            }
-                        };
-
-                        closeBtn.addEventListener('click', handler);
-
-                    } catch (err) {
-                        console.error(err);
-                        openAlertModal('commonAlert', '서버 오류가 발생했습니다.');
+                    if (res.ok) {
+                        try {
+                            const data = await res.json();
+                            if (data?.message) msg = data.message;
+                        } catch (_) {}
+                    } else {
+                        msg = defaultErrorMsg;
+                        try {
+                            const data = await res.json();
+                            if (data?.message) msg = data.message;
+                        } catch (_) {}
                     }
+
+                    // 공통 알림 모달
+                    openAlertModal('commonAlert', msg);
+
+                    const alertModal = document.getElementById('commonAlert');
+                    if (!alertModal) return;
+
+                    const closeBtn = alertModal.querySelector('[data-modal-close]');
+                    if (!closeBtn) return;
+
+                    const handler = () => {
+                        closeBtn.removeEventListener('click', handler);
+
+                        if (res.ok && redirectUrl) {
+                            window.location.href = redirectUrl;
+                        }
+                    };
+
+                    closeBtn.addEventListener('click', handler);
+
+                } catch (err) {
+                    console.error(err);
+                    openAlertModal('commonAlert', '서버 오류가 발생했습니다.');
+                }
+            }
+
+            // 회원탈퇴
+            if (deleteForm) {
+                deleteForm.addEventListener('submit', (e) => {
+                    e.preventDefault();
+
+                    openActionModal('deleteConfirm', '정말 탈퇴하시겠어요?', () => {
+                        sendActionRequest({
+                            url: '/api/member',
+                            method: 'DELETE',
+                            defaultSuccessMsg: '회원 탈퇴가 완료되었습니다.',
+                            defaultErrorMsg: '회원 탈퇴 처리에 실패했습니다.',
+                            redirectUrl: '/login',   // 탈퇴 후 로그인 페이지로
+                        });
+                    });
                 });
-            });
+            }
+
+            // 가족탈퇴
+            if (leaveFamilyBtn) {
+                leaveFamilyBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+
+                    openActionModal('deleteConfirm', '정말 가족 모임에서 탈퇴하시겠어요?', () => {
+                        sendActionRequest({
+                            url: '/api/family/leave',
+                            method: 'POST',
+                            defaultSuccessMsg: '가족 모임에서 탈퇴되었습니다.',
+                            defaultErrorMsg: '가족 탈퇴 처리에 실패했습니다.',
+                            redirectUrl: '/member/family',  // 가족탈퇴 후 이동할 페이지
+                        });
+                    });
+                });
+            }
         })();
     </script>
-
 
 </th:block>
 

--- a/src/main/resources/templates/pages/member/mypage.html
+++ b/src/main/resources/templates/pages/member/mypage.html
@@ -41,14 +41,22 @@
             </a>
 
             <!-- 회원탈퇴 -->
-            <form th:action="@{/api/member}" method="post"
-                  onsubmit="return confirm('정말 탈퇴하시겠어요?');">
-                <input type="hidden" name="_method" value="delete" />
+<!--            <form th:action="@{/api/member}" method="post"-->
+<!--                  onsubmit="return confirm('정말 탈퇴하시겠어요?');">-->
+<!--                <input type="hidden" name="_method" value="delete" />-->
+<!--                <button type="submit"-->
+<!--                        class="mx-auto block w-[200px] rounded-full bg-white px-6 py-3 text-center text-[14px] font-semibold text-gray-400 shadow-md">-->
+<!--                    회원탈퇴-->
+<!--                </button>-->
+<!--            </form>-->
+            <!-- 회원탈퇴 -->
+            <form id="deleteMemberForm" class="w-full">
                 <button type="submit"
                         class="mx-auto block w-[200px] rounded-full bg-white px-6 py-3 text-center text-[14px] font-semibold text-gray-400 shadow-md">
                     회원탈퇴
                 </button>
             </form>
+
         </div>
     </div>
 
@@ -60,6 +68,76 @@
             카카오로 로그인
         </a>
     </section>
+
+    <th:block th:replace="~{fragments/alert-modal :: alertModal('commonAlert', '알림 메시지')}" />
+    <th:block th:replace="~{fragments/action-modal :: actionModal('deleteConfirm', '정말 탈퇴하시겠어요?', '확인', '닫기')}" />
+
+    <script>
+        (function () {
+            const deleteForm = document.getElementById('deleteMemberForm');
+            if (!deleteForm) return;
+
+            deleteForm.addEventListener('submit', (e) => {
+                e.preventDefault();
+
+                openActionModal('deleteConfirm', '정말 탈퇴하시겠어요?', async () => {
+
+                    const token =
+                        document.querySelector('meta[name="_csrf"]')?.content ||
+                        document.querySelector('input[name="_csrf"]')?.value;
+
+                    try {
+                        const res = await fetch('/api/member', {
+                            method: 'DELETE',
+                            headers: {
+                                ...(token ? { 'X-CSRF-TOKEN': token } : {}),
+                            },
+                        });
+
+                        let msg = '회원 탈퇴가 완료되었습니다.';
+
+                        if (res.ok) {
+                            try {
+                                const data = await res.json();
+                                if (data?.message) msg = data.message;
+                            } catch (_) {}
+                        } else {
+                            msg = '회원 탈퇴 처리에 실패했습니다.';
+                            try {
+                                const data = await res.json();
+                                if (data?.message) msg = data.message;
+                            } catch (_) {}
+                        }
+
+                        // 탈퇴 결과 알람 모달
+                        openAlertModal('commonAlert', msg);
+
+                        const alertModal = document.getElementById('commonAlert');
+                        if (!alertModal) return;
+
+                        const closeBtn = alertModal.querySelector('[data-modal-close]');
+                        if (!closeBtn) return;
+
+                        const handler = () => {
+                            closeBtn.removeEventListener('click', handler);
+
+                            if (res.ok) {
+                                // 성공했을 때만 로그인 페이지로 이동
+                                window.location.href = '/login';
+                            }
+                        };
+
+                        closeBtn.addEventListener('click', handler);
+
+                    } catch (err) {
+                        console.error(err);
+                        openAlertModal('commonAlert', '서버 오류가 발생했습니다.');
+                    }
+                });
+            });
+        })();
+    </script>
+
 
 </th:block>
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

1. 가족 탈퇴 API 구현
2. action-modal 프래그먼트 구현
--- 

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 가족 탈퇴 API 구현
- [x] action-modal 프래그먼트 구현

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
actionModal 사용법:
원하는 페이지에 
<th:block th:replace="~{fragments/action-modal :: actionModal('모달id', '메시지', '확인', '닫기')}" />
이때, 모달 id 는 마음대로 명명해도 됩니다.

이걸 적어주고 그 다음 script 태그 안에서
openActionModal('원하는모달idl', '정말 삭제하시겠어요?', () => {
    // 여기 안에 "확인" 버튼 눌렀을 때 실행할 코드 작성
});

이런 식으로 사용하면 됩니다~ 제 mypage.html 에 사용한 코드 있으니 그거 보시면서 해도 돼요