### PR TITLE
[FIX] GlobalMemberAdvice에서 DB 호출 없이 UserPrincipal의 Member 사용하도록 수정

### DIFF
--- a/src/main/java/gamo/web/home/controller/GlobalMemberAdvice.java
+++ b/src/main/java/gamo/web/home/controller/GlobalMemberAdvice.java
@@ -1,6 +1,7 @@
 package gamo.web.home.controller;
 
 import gamo.web.auth.UserPrincipal;
+import gamo.web.member.domain.Member;
 import gamo.web.member.dto.LoginResponseDTO;
 import gamo.web.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -9,15 +10,14 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 @ControllerAdvice
-@RequiredArgsConstructor
 public class GlobalMemberAdvice {
-
-    private final MemberService memberService;
 
     @ModelAttribute("member")
     public LoginResponseDTO addLoggedInMember(@AuthenticationPrincipal UserPrincipal user) {
         if (user == null) return null;
-        Long memberId = memberService.getMemberId(user);
-        return memberService.getMyInfo(memberId);
+
+        // DB 호출 없이 UserPrincipal에 있는 Member 사용
+        Member member = user.getMember();
+        return new LoginResponseDTO(member);
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- GlobalMemberAdvice 코드 수정
기존
```
@ControllerAdvice
@RequiredArgsConstructor
public class GlobalMemberAdvice {

    private final MemberService memberService;

    @ModelAttribute("member")
    public LoginResponseDTO addLoggedInMember(@AuthenticationPrincipal UserPrincipal user) {
        if (user == null) return null;
        Long memberId = memberService.getMemberId(user);
        return memberService.getMyInfo(memberId);
    }
}
```

수정 후
```
@ControllerAdvice
public class GlobalMemberAdvice {

    @ModelAttribute("member")
    public LoginResponseDTO addLoggedInMember(@AuthenticationPrincipal UserPrincipal user) {
        if (user == null) return null;

        // DB 호출 없이 UserPrincipal에 있는 Member 사용
        Member member = user.getMember();
        return new LoginResponseDTO(member);
    }
}
```
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #40 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->