### PR TITLE
[FIX] 홈화면 앨범 리스트 1개만 가져오도록 수정

### DIFF
--- a/src/main/java/gamo/web/photo/repository/AlbumRepository.java
+++ b/src/main/java/gamo/web/photo/repository/AlbumRepository.java
@@ -16,6 +16,5 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Query("SELECT a.family.id FROM Album a WHERE a.album_id = :albumId")
     Long findFamilyIdById(@Param("albumId") Long albumId);
 
-    @Query("SELECT a FROM Album a WHERE a.family.id = :familyId ORDER BY a.album_id DESC")
-    Optional<Album> findLatestAlbumByFamilyId(@Param("familyId") Long familyId);
+    Optional<Album> findTop1ByFamilyIdOrderByAlbumIdDesc(Long familyId);
 }

--- a/src/main/java/gamo/web/photo/service/PhotoService.java
+++ b/src/main/java/gamo/web/photo/service/PhotoService.java
@@ -55,7 +55,7 @@ public class PhotoService {
 
     @Transactional(readOnly = true)
     public String getLatestAlbumThumbnailByFamily(Long familyId) {
-        Album latestAlbum = albumRepository.findLatestAlbumByFamilyId(familyId)
+        Album latestAlbum = albumRepository.findTop1ByFamilyIdOrderByAlbumIdDesc(familyId)
                 .orElse(null);
 
         if (latestAlbum == null) {


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

홈화면 앨범 부분 에러나는 것 고쳤습니다
가족 앨범 여러 개 중 1개만 가져오도록 수정!
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 가족앨범 1개만 가져오도록 수정

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->